### PR TITLE
Add Google Tag Manager and sitemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.0.11",
+    "@next/third-parties": "^14.2.5",
     "@portabletext/react": "^1.0.6",
     "@sanity/image-url": "^1.0.1",
     "@sanity/orderable-document-list": "^1.0.0-v3-studio.3",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,15 @@
-import '../styles/globals.css'
-import type { AppProps } from 'next/app'
+import "../styles/globals.css";
+import { GoogleTagManager } from "@next/third-parties/google";
+
+import type { AppProps } from "next/app";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <>
+      <Component {...pageProps} />
+      <GoogleTagManager gtmId="GTM-M9J75R27" />
+    </>
+  );
 }
 
-export default MyApp
+export default MyApp;

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+  <xml version="1.0" encoding="UTF-8">
+   <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+     <url>
+       <loc>https://chrisangew.codes</loc>
+       <lastmod>2024-07-29</lastmod>
+     </url>
+   </urlset>
+   </xml>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1658,6 +1658,13 @@
   resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.0.tgz#c1b983316307f8f55fee491942b5d244bd2036e2"
   integrity sha512-C/nw6OgQpEULWqs+wgMHXGvlJLguPRFFGqR2TAqWBerQ8J+Sg3z1ZTqwelkSi4FoqStGuZ2UdFHIDN1ySmR1xA==
 
+"@next/third-parties@^14.2.5":
+  version "14.2.5"
+  resolved "https://registry.yarnpkg.com/@next/third-parties/-/third-parties-14.2.5.tgz#7161d266547cabfb61b8af9721f83f8b5463a572"
+  integrity sha512-PDRJm8RZ3rnGNporHKjcdCeZqoW8iJ5uP0clo1Z08TqJiQzuntJ66zrGYCJyqTakx62UJNOp73YsQCFo6kbYYg==
+  dependencies:
+    third-party-capital "1.0.20"
+
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"
   resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz#dbf733a965ca47b1973177dc0bb6c889edcfb129"
@@ -8987,6 +8994,11 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
+
+third-party-capital@1.0.20:
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/third-party-capital/-/third-party-capital-1.0.20.tgz#e218a929a35bf4d2245da9addb8ab978d2f41685"
+  integrity sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==
 
 throat@^6.0.1:
   version "6.0.1"


### PR DESCRIPTION
### Summary

This PR introduces the integration of Google Tag Manager (GTM) using the `@next/third-parties` package and adding a `sitemap.xml` file to the project. The goal is to enable analytics tracking and improve SEO.

### Changes

1. **Google Tag Manager Integration**:
   - Integrated GTM using the `@next/third-parties` package.
   - Added GTM to `pages/_app.tsx`.
   - The GTM container ID used is `GTM-M9J75R27`.

2. **Sitemap**:
   - Added a `sitemap.xml` file to improve SEO by providing search engines with a list of the site’s pages.

### Files Modified

- `pages/_app.tsx`
- `public/sitemap.xml`

### How to Test

1. **Verify Google Tag Manager**:
   - Check the browser console to ensure GTM is loaded correctly.
   - Use the Google Tag Assistant Chrome extension to validate the GTM setup.

2. **Verify Sitemap**:
   - Ensure the `sitemap.xml` file is accessible by visiting `https://chrisagnew.codes/sitemap.xml`.
   - Validate the `sitemap.xml` file using tools like [XML Sitemap Validator](https://www.xml-sitemaps.com/validate-xml-sitemap.html).
