### PR TITLE
Add Vercel Speed Insights to Website

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@portabletext/react": "^3.1.0",
     "@sanity/image-url": "^1.0.2",
     "@sanity/orderable-document-list": "^1.2.1",
+    "@vercel/speed-insights": "^1.0.12",
     "framer-motion": "^11.3.19",
     "next": "^14.2.5",
     "next-sanity": "^9.4.2",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,13 +1,14 @@
 import "../styles/globals.css";
 import { GoogleTagManager } from "@next/third-parties/google";
-
 import type { AppProps } from "next/app";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>
       <Component {...pageProps} />
       <GoogleTagManager gtmId="GTM-M9J75R27" />
+      <SpeedInsights />
     </>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -669,6 +669,11 @@
     "@typescript-eslint/types" "7.2.0"
     eslint-visitor-keys "^3.4.1"
 
+"@vercel/speed-insights@^1.0.12":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@vercel/speed-insights/-/speed-insights-1.0.12.tgz#71c2edffdedae98d34e306d7b0a573e6816898b4"
+  integrity sha512-ZGQ+a7bcfWJD2VYEp2R1LHvRAMyyaFBYytZXsfnbOMkeOvzGNVxUL7aVUvisIrTZjXTSsxG45DKX7yiw6nq2Jw==
+
 "@vercel/stega@0.1.2":
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@vercel/stega/-/stega-0.1.2.tgz#0c20c5c9419c4288b1de58a64b5f9f26c763b25f"


### PR DESCRIPTION
This pull request integrates Vercel Speed Insights into the website to monitor and enhance page load performance. By adding this feature, I aim to:

	•	Gain detailed insights into the website’s performance metrics.
	•	Identify and address performance bottlenecks to improve load times and user experience.
	•	Utilize Vercel’s analytics to monitor and optimize the website’s performance continuously.